### PR TITLE
fix: SonarCloud가 브랜치에서 동작하지 않음  [#9]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,8 @@ name: Build
 on:
   push:
     branches:
-      - master
+      - main
+      - develop
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,10 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
         <sonar.organization>sejong-oss</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>


### PR DESCRIPTION
* Github Actions의 트리거 브랜치를 main, develop로 변경

Cloesed #9 