### PR TITLE
refactor: equals and hashcode 삭제

### DIFF
--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/SkillPayload.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/SkillPayload.java
@@ -4,11 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.mini.kakaoiopenbuilder.skill.payload.action.Action;
-import dev.mini.kakaoiopenbuilder.skill.payload.intent.Intent;
 import dev.mini.kakaoiopenbuilder.skill.payload.bot.Bot;
+import dev.mini.kakaoiopenbuilder.skill.payload.intent.Intent;
 import dev.mini.kakaoiopenbuilder.skill.payload.userrequest.UserRequest;
-
-import java.util.Objects;
 
 public class SkillPayload {
     private Bot bot;
@@ -30,19 +28,6 @@ public class SkillPayload {
 
     public UserRequest getUserRequest() {
         return userRequest;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        SkillPayload that = (SkillPayload) o;
-        return Objects.equals(bot, that.bot) && Objects.equals(intent, that.intent) && Objects.equals(action, that.action) && Objects.equals(userRequest, that.userRequest);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(bot, intent, action, userRequest);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/action/Action.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/action/Action.java
@@ -1,7 +1,6 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.action;
 
 import java.util.Map;
-import java.util.Objects;
 
 public class Action {
     private String id;
@@ -28,19 +27,6 @@ public class Action {
 
     public Map<String, Object> getClientExtra() {
         return clientExtra;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Action action = (Action) o;
-        return Objects.equals(id, action.id) && Objects.equals(name, action.name) && Objects.equals(params, action.params) && Objects.equals(detailParams, action.detailParams) && Objects.equals(clientExtra, action.clientExtra);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, name, params, detailParams, clientExtra);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/action/DetailParams.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/action/DetailParams.java
@@ -1,7 +1,5 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.action;
 
-import java.util.Objects;
-
 public class DetailParams {
     private String origin;
     private String value;
@@ -17,19 +15,6 @@ public class DetailParams {
 
     public String getGroupName() {
         return groupName;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DetailParams that = (DetailParams) o;
-        return Objects.equals(origin, that.origin) && Objects.equals(value, that.value) && Objects.equals(groupName, that.groupName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(origin, value, groupName);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/bot/Bot.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/bot/Bot.java
@@ -1,7 +1,5 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.bot;
 
-import java.util.Objects;
-
 public class Bot {
     private String id;
     private String name;
@@ -12,19 +10,6 @@ public class Bot {
 
     public String getName() {
         return name;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Bot bot = (Bot) o;
-        return Objects.equals(id, bot.id) && Objects.equals(name, bot.name);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, name);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/intent/Extra.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/intent/Extra.java
@@ -1,7 +1,5 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.intent;
 
-import java.util.Objects;
-
 public class Extra {
     private Reason reason;
     private Knowledge knowledge;
@@ -12,19 +10,6 @@ public class Extra {
 
     public Knowledge getKnowledge() {
         return knowledge;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Extra extra = (Extra) o;
-        return Objects.equals(reason, extra.reason) && Objects.equals(knowledge, extra.knowledge);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(reason, knowledge);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/intent/Intent.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/intent/Intent.java
@@ -1,7 +1,5 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.intent;
 
-import java.util.Objects;
-
 public class Intent {
     private String id;
     private String name;
@@ -17,19 +15,6 @@ public class Intent {
 
     public Extra getExtra() {
         return extra;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Intent intent = (Intent) o;
-        return Objects.equals(id, intent.id) && Objects.equals(name, intent.name) && Objects.equals(extra, intent.extra);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, name, extra);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/intent/Knowledge.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/intent/Knowledge.java
@@ -1,7 +1,6 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.intent;
 
 import java.util.List;
-import java.util.Objects;
 
 public class Knowledge {
     private String responseType;
@@ -13,19 +12,6 @@ public class Knowledge {
 
     public List<MatchedKnowledges> getMatchedKnowledges() {
         return matchedKnowledges;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Knowledge knowledge = (Knowledge) o;
-        return Objects.equals(responseType, knowledge.responseType) && Objects.equals(matchedKnowledges, knowledge.matchedKnowledges);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(responseType, matchedKnowledges);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/intent/MatchedKnowledges.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/intent/MatchedKnowledges.java
@@ -1,7 +1,6 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.intent;
 
 import java.util.List;
-import java.util.Objects;
 
 public class MatchedKnowledges {
     private List<String> categories;
@@ -28,19 +27,6 @@ public class MatchedKnowledges {
 
     public String getLandingUrl() {
         return landingUrl;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        MatchedKnowledges that = (MatchedKnowledges) o;
-        return Objects.equals(categories, that.categories) && Objects.equals(question, that.question) && Objects.equals(answer, that.answer) && Objects.equals(imageUrl, that.imageUrl) && Objects.equals(landingUrl, that.landingUrl);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(categories, question, answer, imageUrl, landingUrl);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/intent/Reason.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/intent/Reason.java
@@ -1,7 +1,5 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.intent;
 
-import java.util.Objects;
-
 public class Reason {
     private String code;
     private String message;
@@ -12,19 +10,6 @@ public class Reason {
 
     public String getMessage() {
         return message;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Reason reason = (Reason) o;
-        return Objects.equals(code, reason.code) && Objects.equals(message, reason.message);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(code, message);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/userrequest/Block.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/userrequest/Block.java
@@ -1,7 +1,5 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.userrequest;
 
-import java.util.Objects;
-
 public class Block {
     private String id;
     private String name;
@@ -12,19 +10,6 @@ public class Block {
 
     public String getName() {
         return name;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Block block = (Block) o;
-        return Objects.equals(id, block.id) && Objects.equals(name, block.name);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, name);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/userrequest/Params.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/userrequest/Params.java
@@ -1,7 +1,5 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.userrequest;
 
-import java.util.Objects;
-
 public class Params {
     private String surface;
     private String ignoreMe;
@@ -12,19 +10,6 @@ public class Params {
 
     public String getIgnoreMe() {
         return ignoreMe;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Params params = (Params) o;
-        return Objects.equals(surface, params.surface) && Objects.equals(ignoreMe, params.ignoreMe);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(surface, ignoreMe);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/userrequest/Properties.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/userrequest/Properties.java
@@ -3,8 +3,6 @@ package dev.mini.kakaoiopenbuilder.skill.payload.userrequest;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Objects;
-
 @JsonIgnoreProperties(value = "friend")
 public class Properties {
     private String plusfriendUserKey;
@@ -23,19 +21,6 @@ public class Properties {
 
     public boolean isFriend() {
         return isFriend;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Properties that = (Properties) o;
-        return isFriend == that.isFriend && Objects.equals(plusfriendUserKey, that.plusfriendUserKey) && Objects.equals(appUserId, that.appUserId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(plusfriendUserKey, appUserId, isFriend);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/userrequest/User.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/userrequest/User.java
@@ -1,7 +1,5 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.userrequest;
 
-import java.util.Objects;
-
 public class User {
     private String id;
     private String type;
@@ -17,19 +15,6 @@ public class User {
 
     public Properties getProperties() {
         return properties;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        User user = (User) o;
-        return Objects.equals(id, user.id) && Objects.equals(type, user.type) && Objects.equals(properties, user.properties);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, type, properties);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/userrequest/UserRequest.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/payload/userrequest/UserRequest.java
@@ -1,7 +1,5 @@
 package dev.mini.kakaoiopenbuilder.skill.payload.userrequest;
 
-import java.util.Objects;
-
 public class UserRequest {
     private String timezone;
     private Block block;
@@ -32,19 +30,6 @@ public class UserRequest {
 
     public User getUser() {
         return user;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        UserRequest that = (UserRequest) o;
-        return Objects.equals(timezone, that.timezone) && Objects.equals(block, that.block) && Objects.equals(utterance, that.utterance) && Objects.equals(params, that.params) && Objects.equals(lang, that.lang) && Objects.equals(user, that.user);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(timezone, block, utterance, params, lang, user);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/response/SkillResponse.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/response/SkillResponse.java
@@ -7,7 +7,6 @@ import dev.mini.kakaoiopenbuilder.skill.response.context.ContextControl;
 import dev.mini.kakaoiopenbuilder.skill.response.template.Template;
 
 import java.util.Map;
-import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SkillResponse {
@@ -42,19 +41,6 @@ public class SkillResponse {
 
     public Map<String, String> getData() {
         return data;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        SkillResponse response = (SkillResponse) o;
-        return Objects.equals(version, response.version) && Objects.equals(template, response.template) && Objects.equals(context, response.context) && Objects.equals(data, response.data);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(version, template, context, data);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/response/component/SimpleText.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/response/component/SimpleText.java
@@ -3,8 +3,6 @@ package dev.mini.kakaoiopenbuilder.skill.response.component;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Objects;
-
 public class SimpleText implements Component {
     private String text;
 
@@ -15,19 +13,6 @@ public class SimpleText implements Component {
 
     public String getText() {
         return text;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        SimpleText that = (SimpleText) o;
-        return Objects.equals(text, that.text);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(text);
     }
 
     @Override

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/response/template/Template.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/response/template/Template.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
-import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Template {
@@ -20,19 +19,6 @@ public class Template {
 
     public List<Output> getOutputs() {
         return output;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Template template = (Template) o;
-        return Objects.equals(output, template.output);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(output);
     }
 
     @Override

--- a/src/test/java/dev/mini/kakaoiopenbuilder/skill/payload/SkillPayloadTest.java
+++ b/src/test/java/dev/mini/kakaoiopenbuilder/skill/payload/SkillPayloadTest.java
@@ -3,10 +3,10 @@ package dev.mini.kakaoiopenbuilder.skill.payload;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.mini.kakaoiopenbuilder.skill.payload.intent.Intent;
-import dev.mini.kakaoiopenbuilder.skill.payload.bot.Bot;
-import dev.mini.kakaoiopenbuilder.skill.payload.userrequest.UserRequest;
 import dev.mini.kakaoiopenbuilder.skill.payload.action.Action;
+import dev.mini.kakaoiopenbuilder.skill.payload.bot.Bot;
+import dev.mini.kakaoiopenbuilder.skill.payload.intent.Intent;
+import dev.mini.kakaoiopenbuilder.skill.payload.userrequest.UserRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,7 +42,7 @@ class SkillPayloadTest {
         // that
         assertAll(
                 () -> assertThat(json).doesNotContain("null"),
-                () -> assertThat(actual).isEqualTo(expected)
+                () -> assertThat(actual.toString()).hasToString(expected.toString())
         );
     }
 
@@ -60,7 +60,7 @@ class SkillPayloadTest {
         // that
         assertAll(
                 () -> assertThat(json).doesNotContain("null"),
-                () -> assertThat(actual).isEqualTo(expected)
+                () -> assertThat(actual.toString()).hasToString(expected.toString())
         );
     }
 
@@ -78,7 +78,7 @@ class SkillPayloadTest {
         // that
         assertAll(
                 () -> assertThat(json).doesNotContain("null"),
-                () -> assertThat(actual).isEqualTo(expected)
+                () -> assertThat(actual.toString()).hasToString(expected.toString())
         );
     }
 
@@ -96,7 +96,7 @@ class SkillPayloadTest {
         // that
         assertAll(
                 () -> assertThat(json).doesNotContain("null"),
-                () -> assertThat(actual).isEqualTo(expected)
+                () -> assertThat(actual.toString()).hasToString(expected.toString())
         );
     }
 
@@ -114,7 +114,7 @@ class SkillPayloadTest {
         // that
         assertAll(
                 () -> assertThat(json).doesNotContain("null"),
-                () -> assertThat(actual).isEqualTo(expected)
+                () -> assertThat(actual.toString()).hasToString(expected.toString())
         );
     }
 

--- a/src/test/java/dev/mini/kakaoiopenbuilder/skill/response/SkillDataTest.java
+++ b/src/test/java/dev/mini/kakaoiopenbuilder/skill/response/SkillDataTest.java
@@ -39,7 +39,7 @@ class SkillDataTest {
                 .build();
 
         // that
-        assertThat(actual).isEqualTo(expected);
+        assertThat(actual.toString()).hasToString(expected.toString());
     }
 
     private void loadSkillResponseDataJson() throws IOException {

--- a/src/test/java/dev/mini/kakaoiopenbuilder/skill/response/SkillResponseTest.java
+++ b/src/test/java/dev/mini/kakaoiopenbuilder/skill/response/SkillResponseTest.java
@@ -28,7 +28,7 @@ class SkillResponseTest {
                 .build();
 
         // that
-        assertThat(actual.toString()).isEqualTo(expected.toString());
+        assertThat(actual.toString()).hasToString(expected.toString());
     }
 
     private SkillResponse loadSkillResponseTemplateJson(String filePath) throws IOException {


### PR DESCRIPTION
## 작업 내용
* 근거: Effective Java 10장 equals는 일반 규약을 지켜 재정의하라
1. equals는 필요하지 않은 상황에서는 재정의하지 않는것이 최선이다.
* 사유
1. 테스트 코드에서만 equals를 사용하고 있다.
2. equals와 hashcode가 해당 라이브러리를 사용하고 있는 클라이언트에서 사용될 필요성이 없다.
3. 인스턴스의 논리적 동치성을 검사할 이유가 없다