### PR TITLE
feat: 출력할 수 있는 스킬 컴포넌트의 개수 제한 [#49]

### DIFF
--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/exception/ComponentsOutOfBoundsException.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/exception/ComponentsOutOfBoundsException.java
@@ -1,0 +1,11 @@
+package dev.mini.kakaoiopenbuilder.skill.exception;
+
+public class ComponentsOutOfBoundsException extends IndexOutOfBoundsException {
+
+    private static final String message = "출력할 수 있는 Skill Component의 개수는 1개 이상 3개 이하입니다.";
+
+    public ComponentsOutOfBoundsException() {
+        super(message);
+    }
+
+}

--- a/src/main/java/dev/mini/kakaoiopenbuilder/skill/response/template/TemplateBuilder.java
+++ b/src/main/java/dev/mini/kakaoiopenbuilder/skill/response/template/TemplateBuilder.java
@@ -1,5 +1,6 @@
 package dev.mini.kakaoiopenbuilder.skill.response.template;
 
+import dev.mini.kakaoiopenbuilder.skill.exception.ComponentsOutOfBoundsException;
 import dev.mini.kakaoiopenbuilder.skill.response.component.SimpleText;
 
 import java.util.ArrayList;
@@ -18,7 +19,14 @@ public class TemplateBuilder {
     }
 
     public Template build() {
+        isValidComponent();
         return new Template(output);
+    }
+
+    private void isValidComponent() {
+        if(output.size() < 1 || output.size() > 3) {
+            throw new ComponentsOutOfBoundsException();
+        }
     }
 
 }

--- a/src/test/java/dev/mini/kakaoiopenbuilder/skill/response/SkillResponseTest.java
+++ b/src/test/java/dev/mini/kakaoiopenbuilder/skill/response/SkillResponseTest.java
@@ -1,6 +1,7 @@
 package dev.mini.kakaoiopenbuilder.skill.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.mini.kakaoiopenbuilder.skill.exception.ComponentsOutOfBoundsException;
 import dev.mini.kakaoiopenbuilder.skill.response.template.Template;
 import dev.mini.kakaoiopenbuilder.skill.response.template.TemplateBuilder;
 import org.junit.jupiter.api.DisplayName;
@@ -11,10 +12,37 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SkillResponseTest {
 
     private static final String SKILL_SIMPLE_TEXT_FILE_PATH = "testResources/skill_response_simple_text.json";
+
+    @Test
+    @DisplayName("출력할 수 있는 Skill Component는 1개 미만일 수 없다.")
+    void invalidComponentsExceptionWhenZero() {
+        // given when that
+        assertThatThrownBy(() -> {
+            Template template = new TemplateBuilder()
+                    .build();
+        }).isInstanceOf(ComponentsOutOfBoundsException.class)
+                .hasMessage("출력할 수 있는 Skill Component의 개수는 1개 이상 3개 이하입니다.");
+    }
+
+    @Test
+    @DisplayName("출력할 수 있는 Skill Component의 개수는 3개 초과일 수 없다.")
+    void invalidComponentsExceptionWhenExceedsThree() {
+        // given when that
+        assertThatThrownBy(() -> {
+            Template template = new TemplateBuilder()
+                    .addSimpleText("test1")
+                    .addSimpleText("test2")
+                    .addSimpleText("test3")
+                    .addSimpleText("test4")
+                    .build();
+        }).isInstanceOf(ComponentsOutOfBoundsException.class)
+                .hasMessage("출력할 수 있는 Skill Component의 개수는 1개 이상 3개 이하입니다.");
+    }
 
     @Test
     @DisplayName("SimpleText 포맷이 동일한지 검증한다.")


### PR DESCRIPTION
## 작업 내용
* 스킬 컴포넌트의 개수는 1개 이상 3개 이하여야 한다.
* 만약 넘거나 모자르다면 ComponentsOutOfBoundsException 발생