### PR TITLE
chore: common 경로의 클래스들을 coverage 측정 대상에서 제외

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
                     <excludes>
                         <exclude>dev/mini/**/Main.class</exclude>
                         <exclude>dev/mini/**/util/*.class</exclude>
+                        <exclude>dev/mini/**/response/common/*.class</exclude>
                     </excludes>
                 </configuration>
                 <executions>


### PR DESCRIPTION
## 작업 내용
* common의 대부분은 자료구조로서 테스트 코드 작성이 필요없다고 판단되기 때문에 coverage 측정 대상에서 제외한다.